### PR TITLE
Support modular and monolithic arrangement for building libraries.

### DIFF
--- a/test/Jamfile
+++ b/test/Jamfile
@@ -3,6 +3,9 @@
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or http://www.boost.org/LICENSE_1_0.txt)
 
+# WARNING: This project *only* works in the context of a full Boost structure
+# with an up to date super-project.
+
 import modules ;
 import sequence ;
 import set ;
@@ -26,18 +29,24 @@ local rule .info ( messages * )
     }
 }
 
+path-constant boost-root : ../../.. ;
+
 local all-libraries = [ MATCH .*libs/(.*)/build/.* :
-    [ glob ../../../libs/*/build/Jamfile.v2 ]
-    [ glob ../../../libs/*/build/Jamfile ] ] ;
+    [ glob $(boost-root)/libs/*/build/Jamfile.v2 ]
+    [ glob $(boost-root)/libs/*/build/Jamfile ] ] ;
 
 all-libraries = [ sequence.unique $(all-libraries) ] ;
+
+local all-libraries-modular
+    = [ MATCH .*libs/(.*)/build.jam : [ glob $(boost-root)/libs/*/build.jam ] ] ;
 
 # The function_types library has a Jamfile, but it's used for maintenance
 # purposes, there's no library to build and install.
 
-all-libraries = [ set.difference $(all-libraries) : function_types ] ;
+all-libraries = [ set.difference $(all-libraries) : function_types headers ] ;
 
-#ECHO all-libraries: $(all-libraries) ;
+# ECHO "all-libraries:" $(all-libraries) ;
+# ECHO "all-libraries-modular:" $(all-libraries-modular) ;
 
 rule alias-sources-impl ( project name : property-set : sources * )
 {
@@ -70,12 +79,16 @@ rule alias-sources-impl ( project name : property-set : sources * )
     return $(result) ;
 }
 
-path-constant ROOT : ../../.. ;
-
 for local lib in $(all-libraries)
 {
-    local path = [ NORMALIZE_PATH /$(ROOT)/libs/$(lib)/build ] ;
-    generate library-$(lib) : $(path)//stage : <generating-rule>@alias-sources-impl ;
+    if $(lib) in $(all-libraries-modular)
+    {
+        generate library-$(lib) : /boost/$(lib)//stage : <generating-rule>@alias-sources-impl ;
+    }
+    else
+    {
+        generate library-$(lib) : /boost/$(lib)/build//stage : <generating-rule>@alias-sources-impl ;
+    }
 }
 
 for local lib in $(all-libraries)


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854
